### PR TITLE
Add type hints to Tween()

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Tween(begin, end, duration, easing, easing_mode, boomerang, loop, reps)
 | `end`     | `float`  | The end value of a property (default: `1.0`)        |
 | `duration`| `int`    | The length of time that an animation takes to complete (default: `600 ms`) |
 | `easing`  | `Easing` | The type of easing to apply. (default: `Easing.LINEAR`) |
-| `easing_mode | `EasingMode` | The mode of easing `IN`, `OUT`, `IN_OUT`, (default: `None`) |
+| `easing_mode` | `EasingMode` | The mode of easing `IN`, `OUT`, `IN_OUT`, (default: `IN`) |
 | `boomerang` | `bool` | Returns the animation back to its starting point and vice versa. (default: `False`) |
 | `loop`    | `bool`  | Loops the animation. When used with `boomerang`, it does the back and forth animation. (default: `False`) |
 | `reps`  | `int` | Number of times the animation will be repeated. Zero means infinite. (default: `0`) |

--- a/tween.py
+++ b/tween.py
@@ -28,7 +28,7 @@ class Tween:
                  begin: float = 0.0, end: float = 1.0,
                  duration: int = 600,
                  easing: Easing = Easing.LINEAR,
-                 easing_mode: EasingMode = None,
+                 easing_mode: EasingMode = EasingMode.IN,
                  boomerang: bool = False,
                  loop: bool = False,
                  reps: int = 0):

--- a/tween.py
+++ b/tween.py
@@ -55,7 +55,7 @@ class Tween:
         self._step = 0
 
         # Determine which function to use
-        self._ease = Easing.LINEAR
+        self._ease = None
         self._eval_func()
 
     def _eval_func(self):

--- a/tween.py
+++ b/tween.py
@@ -25,13 +25,13 @@ class EasingMode(Enum):
 
 class Tween:
     def __init__(self,
-                 begin=0.0, end=1.0,
-                 duration=600.0,
-                 easing=Easing.LINEAR,
-                 easing_mode=None,
-                 boomerang=False,
-                 loop=False,
-                 reps=0):
+                 begin: float = 0.0, end: float = 1.0,
+                 duration: int = 600,
+                 easing: Easing = Easing.LINEAR,
+                 easing_mode: EasingMode = None,
+                 boomerang: bool = False,
+                 loop: bool = False,
+                 reps: int = 0):
 
         self._begin = begin
         self._origin = begin
@@ -55,7 +55,7 @@ class Tween:
         self._step = 0
 
         # Determine which function to use
-        self._ease = None
+        self._ease = Easing.LINEAR
         self._eval_func()
 
     def _eval_func(self):


### PR DESCRIPTION
Adds type hints to `Tween.__init__()`.

Sets the default value of `easing_mode` to match type hint without having to making the type `Optional`.